### PR TITLE
Fix error on service reload

### DIFF
--- a/debian/backuppc.init
+++ b/debian/backuppc.init
@@ -66,7 +66,7 @@ case "$1" in
 	;;
   reload|force-reload)
     log_begin_msg "Reloading $NAME configuration files..."
-    start-stop-daemon --stop --pidfile /var/run/backuppc/BackupPC.pid --signal 1
+    start-stop-daemon --stop --pidfile /var/run/backuppc/BackupPC.pid -u $USER --signal 1
     log_end_msg $?
     ;;
   status)


### PR DESCRIPTION
Tested on Devuan 3 Beowulf (Debian 10 Buster)

When `$Conf{RunDir} = '/var/run/backuppc'` and `/var/run/backuppc/BackupPC.pid` is `chown backuppc:backuppc`, running `service backuppc reload` results in the warning/error:

```
[....] Reloading backuppc configuration files...start-stop-daemon: matching only on non-root pidfile /var/run/backuppc/BackupPC.pid is insecure
```

This can be fixed by updating the initscript to check on `$USER` during the reload operation.