### PR TITLE
Pass --no-set-perms to configure.pl

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -70,6 +70,7 @@ install: build
 	( cd ./buildroot/; \
 		chmod 755 ./configure.pl; \
 		./configure.pl --batch --no-fhs --uid-ignore --hostname XXXXXX \
+			--no-set-perms \
 			--bin-path perl=/usr/bin/perl \
 			--bin-path tar=/bin/tar \
 			--bin-path smbclient=/usr/bin/smbclient \


### PR DESCRIPTION
The backuppc user does not yet exist at package build time. The postinst script will create the backuppc user and chown the files as appropriate.

Fixes #5.