### PR TITLE
Change debian/package/format to '3.0 (quilt)'

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
'3.0 (native)' is reserved for native packages, and BackupPC is not a native package.

Fixes #7